### PR TITLE
Close annotated VCF

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 import multiprocessing
 
 setup(name='snpEffWrapper',
-      version='0.2.0',
+      version='0.2.1',
       scripts=[
         'scripts/snpEffBuildAndRun'
       ],

--- a/snpEffWrapper/wrapper.py
+++ b/snpEffWrapper/wrapper.py
@@ -305,6 +305,7 @@ def move_annotated_vcf(annotated_vcf, output_vcf):
     annotated_vcf.seek(0)
     logger.info("Writing output to stdout")
     print(annotated_vcf.read(), file=output_vcf)
+    annotated_vcf.close()
   else:
     annotated_vcf.close()
     output_vcf.close()


### PR DESCRIPTION
NFS didn't like trying to delete a folder with a file still open :(

annotated_vcf is a temporary copy of the annotated VCF which is checked for silly mistakes before moving it to the chosen output location.
