### PR TITLE
Ignore some of the INFO fields in a VCF

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -9,10 +9,10 @@ SNPEFF_VERSION="v4_1l_core"
 SNPEFF_DOWNLOAD_URL="http://sourceforge.net/projects/snpeff/files/snpEff_${SNPEFF_VERSION}.zip"
 
 # Make an install location
-if [ ! -d "${HOME}/dependencies" ]; then
-  mkdir ${HOME}/dependencies
+if [ ! -d "${start_dir}/build" ]; then
+  mkdir "${start_dir}/build"
 fi
-build_dir="${HOME}/dependencies"
+build_dir="${start_dir}/build"
 
 # DOWNLOAD ALL THE THINGS
 download () {

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 import multiprocessing
 
 setup(name='snpEffWrapper',
-      version='0.2.3',
+      version='0.2.4',
       scripts=[
         'scripts/snpEffBuildAndRun'
       ],

--- a/snpEffWrapper/tests/test_wrapper.py
+++ b/snpEffWrapper/tests/test_wrapper.py
@@ -267,6 +267,15 @@ CHROM1	400	.	G	A	.	.	ANN=A|foo|bar|	GT	0	1
 
     fake_vcf = StringIO("""\
 ##fileformat=VCFv4.1
+##INFO=<ID=FOO,Number=1,Type=Float,Description="Some information",Version="3">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample_1	sample_2
+CHROM1	400	.	G	A	.	.	ANN=A|foo|bar|	GT	0	1
+""")
+    self.assertEqual(check_annotations(fake_vcf), None)
+    warn_mock.assert_not_called()
+
+    fake_vcf = StringIO("""\
+##fileformat=VCFv4.1
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample_1	sample_2
 CHROM1	400	.	G	A	.	.	ANN=A|foo|bar|ERROR_CHROMOSOME_NOT_FOUND	GT	0	1
 """)


### PR DESCRIPTION
The VCF parser I'm using doesn't like the Source or Version fields in the INFO lines.  A future version (v0.6.8) appears to fix this issue, but in the mean time, this hack removes the offending material before the VCF parser sees it
